### PR TITLE
Fix manual prune date range query

### DIFF
--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -182,7 +182,7 @@ function history_prune($startdate,$stopdate)
 DELETE
 FROM '.HISTORY_TABLE.' 
 WHERE date < "'.$stopdate.'" 
-AND date > "'.$startdate.';';
+AND date > "'.$startdate.'"';
 
     $r = pwg_query($query);
 


### PR DESCRIPTION
Executing a manual prune with date range (*not* the same day) resulted
in an SQL query error with
AND date > "2021-01-13;
that should be
AND date > "2021-01-13"

Regression from

    commit d8ceb81e49253be999330f90a0c870667f85e094
    CommitDate: Fri Mar 16 14:15:45 2018 +0100

        "summarized" column in History table is no longer used since Piwigo
        2.9. Removed "summarized" from sql requests.
